### PR TITLE
Fix theme selector width

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -176,6 +176,9 @@ textarea, input, select {
     width: 100%;
     max-width: 100%;
 }
+#themeSelector {
+    width: auto;
+}
 
 @keyframes spin {
   0% { transform: rotate(0deg); }
@@ -201,7 +204,7 @@ textarea, input, select {
     ">
         ☕ Buy Me a Coffee
     </a>
-    <select id="themeSelector" style="padding: 6px; border-radius: 6px;">
+    <select id="themeSelector" style="width: auto; padding: 4px 8px; border-radius: 6px; font-size: 0.9rem;">
         <option value="">Default</option>
         <option value="ocean-theme">Ocean Breeze</option>
         <option value="dark-theme">Dark Mode</option>


### PR DESCRIPTION
## Summary
- override global select width for #themeSelector
- allow the theme dropdown to fit next to the Buy Me a Coffee button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f8997319c832c846b79e6489c885b